### PR TITLE
Fix GH actions to use later, working versions of rubygems

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -14,6 +14,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.6
+          rubygems: 3.2.33
           bundler: 2.5
       - name: Install bundle
         run: bundle
@@ -45,6 +46,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          rubygems: latest
           bundler: 2.5
       - name: Install bundle
         run: bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # (unreleased)
 
+* (internal) Github actions: Fix build problems by specifying a working version of rubygems for linting and simply using "latest" for tests (don't use the default from the respective rubies)
+
 # 0.8.1 (2024-11-11)
 
 * (internal) Add some metadata for rubygems.org


### PR DESCRIPTION
Specify a working version of rubygems for linting and simply use "latest" for tests (don't use the default from the respective rubies).

This should fix a build error (sqlite3-ruby using packaged sqlite3 "in `parse_stream': undefined method `parse' for #<Psych::Parser...".